### PR TITLE
✨feat: adicionar funcionalidade para ligar o LED verde (GPIO 11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,20 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 2.1.0)
+set(toolchainVersion 13_3_Rel1)
+set(picotoolVersion 2.1.0)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
 # Generated Cmake Pico project file
 
 cmake_minimum_required(VERSION 3.13)

--- a/src/main.c
+++ b/src/main.c
@@ -78,6 +78,8 @@ int main() {
         switch (opc) {
             // exemplo
             case 1:
+                turn_led_on(LED_GREEN);
+                disable_all_gpios_except(gpios_task.used_gpios, LED_GREEN);
                 break;
             case 2:
                 turn_led_on(LED_BLUE);


### PR DESCRIPTION
- Implementada a opção 1 no menu para ligar o LED verde (GPIO 11).
- Adicionada a chamada para `turn_led_on(LED_GREEN)` e `disable_all_gpios_except(gpios_task.used_gpios, LED_GREEN)` no case 1 do switch.